### PR TITLE
chore: SGL & SGLLiquidation size refactoring

### DIFF
--- a/contracts/markets/singularity/SGLInterestHelper.sol
+++ b/contracts/markets/singularity/SGLInterestHelper.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.22;
+
+// External
+import {RebaseLibrary, Rebase} from "@boringcrypto/boring-solidity/contracts/libraries/BoringRebase.sol";
+import {ISingularity} from "tapioca-periph/interfaces/bar/ISingularity.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+// Tapioca
+import {ISingularity} from "tapioca-periph/interfaces/bar/ISingularity.sol";
+import {IYieldBox} from "tapioca-periph/interfaces/yieldbox/IYieldBox.sol";
+
+/*
+
+████████╗ █████╗ ██████╗ ██╗ ██████╗  ██████╗ █████╗ 
+╚══██╔══╝██╔══██╗██╔══██╗██║██╔═══██╗██╔════╝██╔══██╗
+   ██║   ███████║██████╔╝██║██║   ██║██║     ███████║
+   ██║   ██╔══██║██╔═══╝ ██║██║   ██║██║     ██╔══██║
+   ██║   ██║  ██║██║     ██║╚██████╔╝╚██████╗██║  ██║
+   ╚═╝   ╚═╝  ╚═╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝
+   
+*/
+
+interface ISGLInterestHelper {
+    struct InterestRateCall {
+        IYieldBox yieldBox;
+        ISingularity.AccrueInfo accrueInfo;
+        uint256 assetId;
+        Rebase totalAsset;
+        Rebase totalBorrow;
+        uint256 protocolFee;
+        uint256 interestElasticity;
+        uint256 minimumTargetUtilization;
+        uint256 maximumTargetUtilization;
+        uint64 minimumInterestPerSecond;
+        uint64 maximumInterestPerSecond;
+        uint64 startingInterestPerSecond;
+    }
+
+    function getInterestRate(
+        InterestRateCall memory data
+    )
+        external
+        view
+        returns (
+            ISingularity.AccrueInfo memory _accrueInfo,
+            Rebase memory _totalBorrow,
+            Rebase memory _totalAsset,
+            uint256 extraAmount,
+            uint256 feeFraction,
+            uint256 utilization
+        );
+}
+contract SGLInterestHelper is ISGLInterestHelper {
+    using RebaseLibrary for Rebase;
+    using SafeCast for uint256;
+
+    uint256 private constant FULL_UTILIZATION = 1e18;
+    uint256 private constant UTILIZATION_PRECISION = 1e18;
+    uint256 private constant FEE_PRECISION = 1e5;
+
+    // ************************** //
+    // *** PRIVATE FUNCTIONS *** //
+    // ************************* //
+    function getInterestRate(
+        InterestRateCall memory data
+    )
+        external
+        override
+        view
+        returns (
+            ISingularity.AccrueInfo memory _accrueInfo,
+            Rebase memory _totalBorrow,
+            Rebase memory _totalAsset,
+            uint256 extraAmount,
+            uint256 feeFraction,
+            uint256 utilization
+        )
+    {
+        _accrueInfo = data.accrueInfo;
+        _totalBorrow = data.totalBorrow;
+        _totalAsset = data.totalAsset;
+        extraAmount = 0;
+        feeFraction = 0;
+
+        uint256 fullAssetAmount = data.yieldBox.toAmount(data.assetId, _totalAsset.elastic, false) + _totalBorrow.elastic;
+
+        utilization =
+            fullAssetAmount == 0 ? 0 : (uint256(_totalBorrow.elastic) * UTILIZATION_PRECISION) / fullAssetAmount;
+
+        // Number of seconds since accrue was called
+        uint256 elapsedTime = block.timestamp - _accrueInfo.lastAccrued;
+        if (elapsedTime == 0) {
+            return (_accrueInfo, data.totalBorrow, data.totalAsset, 0, 0, utilization);
+        }
+        _accrueInfo.lastAccrued = block.timestamp.toUint64();
+
+        if (_totalBorrow.base == 0) {
+            // If there are no borrows, reset the interest rate
+            if (_accrueInfo.interestPerSecond != data.startingInterestPerSecond) {
+                _accrueInfo.interestPerSecond = data.startingInterestPerSecond;
+            }
+            return (_accrueInfo, _totalBorrow, data.totalAsset, 0, 0, utilization);
+        }
+
+        // Accrue interest
+        extraAmount = (uint256(_totalBorrow.elastic) * _accrueInfo.interestPerSecond * elapsedTime) / 1e18;
+        _totalBorrow.elastic += extraAmount.toUint128();
+
+        //take accrued values into account
+        fullAssetAmount = data.yieldBox.toAmount(data.assetId, _totalAsset.elastic, false) + _totalBorrow.elastic;
+
+        uint256 feeAmount = (extraAmount * data.protocolFee) / FEE_PRECISION; // % of interest paid goes to fee
+        feeFraction = (feeAmount * _totalAsset.base) / (fullAssetAmount - feeAmount);
+        _accrueInfo.feesEarnedFraction += feeFraction.toUint128();
+        _totalAsset.base = _totalAsset.base + feeFraction.toUint128();
+
+        utilization =
+            fullAssetAmount == 0 ? 0 : (uint256(_totalBorrow.elastic) * UTILIZATION_PRECISION) / fullAssetAmount;
+
+        // Update interest rate
+        if (utilization < data.minimumTargetUtilization) {
+            uint256 underFactor =
+                ((data.minimumTargetUtilization - utilization) * 1e18) / data.minimumTargetUtilization;
+            uint256 scale = data.interestElasticity + (underFactor * underFactor * elapsedTime);
+            _accrueInfo.interestPerSecond =
+                ((uint256(_accrueInfo.interestPerSecond) * data.interestElasticity) / scale).toUint64();
+            if (_accrueInfo.interestPerSecond < data.minimumInterestPerSecond) {
+                _accrueInfo.interestPerSecond = data.minimumInterestPerSecond; // 0.25% APR minimum
+            }
+        } else if (utilization > data.maximumTargetUtilization) {
+            uint256 overFactor = ((utilization - data.maximumTargetUtilization) * 1e18) / (FULL_UTILIZATION - data.maximumTargetUtilization);
+            uint256 scale = data.interestElasticity + (overFactor * overFactor * elapsedTime);
+            uint256 newInterestPerSecond = (uint256(_accrueInfo.interestPerSecond) * scale) / data.interestElasticity;
+            if (newInterestPerSecond > data.maximumInterestPerSecond) {
+                newInterestPerSecond = data.maximumInterestPerSecond; // 1000% APR maximum
+            }
+            _accrueInfo.interestPerSecond = newInterestPerSecond.toUint64();
+        }
+    }
+}

--- a/contracts/markets/singularity/SGLStorage.sol
+++ b/contracts/markets/singularity/SGLStorage.sol
@@ -50,6 +50,8 @@ contract SGLStorage is Ownable, Market, ReentrancyGuard {
     /// @notice borrowing opening fee
     uint256 public borrowOpeningFee = 50; //0.05%
 
+    address public interestHelper;
+
     // ************** //
     // *** EVENTS *** //
     // ************** //
@@ -83,6 +85,8 @@ contract SGLStorage is Ownable, Market, ReentrancyGuard {
     event MaximumInterestPerSecondUpdated(uint256 indexed oldVal, uint256 indexed newVal);
     /// @notice event emitted when the interest elasticity updated
     event InterestElasticityUpdated(uint256 indexed oldVal, uint256 indexed newVal);
+    /// @notice event emitted when the interest helper is updated
+    event InterestHelperUpdated(address indexed oldVal, address indexed newVal);
 
     // ***************** //
     // *** CONSTANTS *** //

--- a/contracts/markets/singularity/SGLStorage.sol
+++ b/contracts/markets/singularity/SGLStorage.sol
@@ -39,15 +39,8 @@ contract SGLStorage is Ownable, Market, ReentrancyGuard {
     /// @notice total assets share & amount
     Rebase public totalAsset; // elastic = yieldBox shares held by the Singularity, base = Total fractions held by asset suppliers
 
-    // YieldBox shares, from -> Yb asset type -> shares
-    bytes32 internal ASSET_SIG = 0x0bd4060688a1800ae986e4840aebc924bb40b5bf44de4583df2257220b54b77c; // keccak256("asset")
-    bytes32 internal COLLATERAL_SIG = 0x7d1dc38e60930664f8cbf495da6556ca091d2f92d6550877750c049864b18230; // keccak256("collateral")
-    /// @notice collateralization rate
-    uint256 public lqCollateralizationRate = 25000; // 25%
-
     uint256 public minimumTargetUtilization;
     uint256 public maximumTargetUtilization;
-    uint256 public fullUtilizationMinusMax;
 
     uint64 public minimumInterestPerSecond;
     uint64 public maximumInterestPerSecond;
@@ -80,8 +73,6 @@ contract SGLStorage is Ownable, Market, ReentrancyGuard {
     event LogRepay(address indexed from, address indexed to, uint256 indexed amount, uint256 part);
     /// @notice event emitted when fees are extracted
     event LogWithdrawFees(address indexed feeTo, uint256 indexed feesEarnedFraction);
-    /// @notice event emitted when fees are deposited to YieldBox
-    event LogYieldBoxFeesDeposit(uint256 indexed feeShares, uint256 indexed ethAmount);
     /// @notice event emitted when the minimum target utilization is updated
     event MinimumTargetUtilizationUpdated(uint256 indexed oldVal, uint256 indexed newVal);
     /// @notice event emitted when the maximum target utilization is updated
@@ -92,23 +83,12 @@ contract SGLStorage is Ownable, Market, ReentrancyGuard {
     event MaximumInterestPerSecondUpdated(uint256 indexed oldVal, uint256 indexed newVal);
     /// @notice event emitted when the interest elasticity updated
     event InterestElasticityUpdated(uint256 indexed oldVal, uint256 indexed newVal);
-    /// @notice event emitted when the LQ collateralization rate is updated
-    event LqCollateralizationRateUpdated(uint256 indexed oldVal, uint256 indexed newVal);
-    /// @notice event emitted when the order book liquidation multiplier rate is updated
-    event OrderBookLiquidationMultiplierUpdated(uint256 indexed oldVal, uint256 indexed newVal);
-    /// @notice event emitted when the bid execution swapper is updated
-    event BidExecutionSwapperUpdated(address indexed newAddress);
-    /// @notice event emitted when the usdo swapper is updated
-    event UsdoSwapperUpdated(address indexed newAddress);
 
     // ***************** //
     // *** CONSTANTS *** //
     // ***************** //
     uint256 internal constant FULL_UTILIZATION = 1e18;
     uint256 internal constant UTILIZATION_PRECISION = 1e18;
-
-    uint256 internal constant FACTOR_PRECISION = 1e18;
-
     constructor() MarketERC20("Tapioca Singularity") {}
 
     // ********************** //

--- a/contracts/markets/singularity/Singularity.sol
+++ b/contracts/markets/singularity/Singularity.sol
@@ -311,8 +311,17 @@ contract Singularity is MarketStateView, SGLCommon {
         uint256 _maximumTargetUtilization,
         uint64 _minimumInterestPerSecond,
         uint64 _maximumInterestPerSecond,
-        uint256 _interestElasticity
+        uint256 _interestElasticity,
+        address _interestHelper
     ) external onlyOwner {
+        // this needs to be set first
+        // if `interestHelper` is address(0), the next _accrue() call won't work
+        if (_interestHelper != address(0)) {
+            emit InterestHelperUpdated(interestHelper, _interestHelper);
+            interestHelper = _interestHelper;
+
+        }
+        
         _accrue();
 
         if (_borrowOpeningFee > FEE_PRECISION) revert NotValid();

--- a/contracts/markets/singularity/Singularity.sol
+++ b/contracts/markets/singularity/Singularity.sol
@@ -37,8 +37,8 @@ import {SGLBorrow} from "./SGLBorrow.sol";
 
 /// @title Tapioca market
 contract Singularity is MarketStateView, SGLCommon {
-    using RebaseLibrary for Rebase;
     using SafeCast for uint256;
+    using RebaseLibrary for Rebase;
 
     // ************ //
     // *** VARS *** //
@@ -55,7 +55,6 @@ contract Singularity is MarketStateView, SGLCommon {
     // ************** //
     // *** ERRORS *** //
     // ************** //
-    error BadPair();
     error NotValid();
     error ModuleNotSet();
     error NotAuthorized();
@@ -101,14 +100,6 @@ contract Singularity is MarketStateView, SGLCommon {
         yieldBox = IYieldBox(_initMemoryData.penrose_.yieldBox());
         _transferOwnership(address(penrose));
 
-        if (address(_initMemoryTokensData._collateral) == address(0)) {
-            revert BadPair();
-        }
-        if (address(_initMemoryTokensData._asset) == address(0)) {
-            revert BadPair();
-        }
-        if (address(_initMemoryData._oracle) == address(0)) revert BadPair();
-
         _initModules(
             _initMemoryModulesData._liquidationModule,
             _initMemoryModulesData._borrowModule,
@@ -136,14 +127,12 @@ contract Singularity is MarketStateView, SGLCommon {
         address _collateralModule,
         address _leverageModule
     ) private {
-        if (_liquidationModule == address(0)) revert NotValid();
-        if (_collateralModule == address(0)) revert NotValid();
-        if (_borrowModule == address(0)) revert NotValid();
-        if (_leverageModule == address(0)) revert NotValid();
-        liquidationModule = SGLLiquidation(_liquidationModule);
-        collateralModule = SGLCollateral(_collateralModule);
-        borrowModule = SGLBorrow(_borrowModule);
-        leverageModule = SGLLeverage(_leverageModule);
+        assembly {
+            sstore(liquidationModule.slot, _liquidationModule)
+            sstore(collateralModule.slot, _collateralModule)
+            sstore(borrowModule.slot, _borrowModule)
+            sstore(leverageModule.slot, _leverageModule)
+        }
     }
 
     function _initCoreStorage(
@@ -154,12 +143,15 @@ contract Singularity is MarketStateView, SGLCommon {
         ITapiocaOracle _oracle,
         ILeverageExecutor _leverageExecutor
     ) private {
-        asset = _asset;
-        collateral = _collateral;
-        assetId = _assetId;
-        collateralId = _collateralId;
-        oracle = _oracle;
-        leverageExecutor = _leverageExecutor;
+        assembly {
+            // Store the values directly into their respective slots
+            sstore(asset.slot, _asset)
+            sstore(collateral.slot, _collateral)
+            sstore(assetId.slot, _assetId)
+            sstore(collateralId.slot, _collateralId)
+            sstore(oracle.slot, _oracle)
+            sstore(leverageExecutor.slot, _leverageExecutor)
+        }
     }
 
     function _initDefaultValues(
@@ -173,27 +165,30 @@ contract Singularity is MarketStateView, SGLCommon {
         require(
             liquidationCollateralizationRate > collateralizationRate, "SGL: liquidationCollateralizationRate not valid"
         );
-        minimumInterestPerSecond = 158548960; // approx 0.5% APR
-        maximumInterestPerSecond = 317097920000; // approx 1000% APR
+        assembly {
+            sstore(minimumInterestPerSecond.slot, 158548960) // approx 0.5% APR
+            sstore(maximumInterestPerSecond.slot, 317097920000) // approx 1000% APR
+        }
         interestElasticity = 28800e36; // Half or double in 28800 seconds (8 hours) if linear
         startingInterestPerSecond = minimumInterestPerSecond;
         accrueInfo.interestPerSecond = startingInterestPerSecond; // 1% APR, with 1e18 being 100%
         updateExchangeRate();
-        //default fees
-        protocolFee = 10000; // 10%; used for accrual
-        borrowOpeningFee = 50; // 0.05%
-        //liquidation
-        liquidationMultiplier = 12000; //12%
-        lqCollateralizationRate = 25000;
-        EXCHANGE_RATE_PRECISION = _exchangeRatePrecision > 0 ? _exchangeRatePrecision : 1e18;
-        minLiquidatorReward = 8e4;
-        maxLiquidatorReward = 9e4;
-        liquidationBonusAmount = 1e4;
-        minimumTargetUtilization = 3e17;
-        maximumTargetUtilization = 5e17;
-        fullUtilizationMinusMax = FULL_UTILIZATION - maximumTargetUtilization;
-        rateValidDuration = 24 hours;
+        assembly {
+            //default fees
+            sstore(protocolFee.slot, 10000) // 10%; used for accrual
+            sstore(borrowOpeningFee.slot, 50) // 0.05%
 
+            //liquidation
+            sstore(liquidationMultiplier.slot, 12000) //12%
+            sstore(minLiquidatorReward.slot, 80000) //8e4
+            sstore(maxLiquidatorReward.slot, 90000) //9e4
+            sstore(liquidationBonusAmount.slot, 10000) //1e4
+            sstore(minimumTargetUtilization.slot, 300000000000000000) //3e17
+            sstore(maximumTargetUtilization.slot, 500000000000000000) //5e17
+            sstore(rateValidDuration.slot, 86400) //24 hours
+        }
+
+        EXCHANGE_RATE_PRECISION = _exchangeRatePrecision > 0 ? _exchangeRatePrecision : 1e18;
         conservator = owner();
     }
 
@@ -214,16 +209,14 @@ contract Singularity is MarketStateView, SGLCommon {
         successes = new bool[](calls.length);
         results = new bytes[](calls.length);
         if (modules.length != calls.length) revert NotValid();
-        unchecked {
-            for (uint256 i; i < calls.length; i++) {
-                (bool success, bytes memory result) = _extractModule(modules[i]).delegatecall(calls[i]);
+        for (uint256 i; i < calls.length; i++) {
+            (bool success, bytes memory result) = _extractModule(modules[i]).delegatecall(calls[i]);
 
-                if (!success && revertOnFail) {
-                    revert(abi.decode(_getRevertMsg(result), (string)));
-                }
-                successes[i] = success;
-                results[i] = !success ? _getRevertMsg(result) : result;
+            if (!success && revertOnFail) {
+                revert(abi.decode(_getRevertMsg(result), (string)));
             }
+            successes[i] = success;
+            results[i] = !success ? _getRevertMsg(result) : result;
         }
     }
 
@@ -338,7 +331,6 @@ contract Singularity is MarketStateView, SGLCommon {
 
             emit MaximumTargetUtilizationUpdated(maximumTargetUtilization, _maximumTargetUtilization);
             maximumTargetUtilization = _maximumTargetUtilization;
-            fullUtilizationMinusMax = FULL_UTILIZATION - maximumTargetUtilization;
         }
 
         if (_minimumInterestPerSecond > 0) {
@@ -388,6 +380,45 @@ contract Singularity is MarketStateView, SGLCommon {
         if (module == address(0)) revert ModuleNotSet();
 
         return module;
+    }
+
+    /// @dev Concrete implementation of `addAsset`.
+    function _addAsset(address from, address to, bool skim, uint256 share) private returns (uint256 fraction) {
+        Rebase memory _totalAsset = totalAsset;
+        uint256 totalAssetShare = _totalAsset.elastic;
+        uint256 allShare = _totalAsset.elastic + yieldBox.toShare(assetId, totalBorrow.elastic, true);
+        fraction = allShare == 0 ? share : (share * _totalAsset.base) / allShare;
+        if (_totalAsset.base + fraction.toUint128() < 1000) {
+            return 0;
+        }
+        totalAsset = _totalAsset.add(share, fraction);
+
+        balanceOf[to] += fraction;
+        emit Transfer(address(0), to, fraction);
+
+        _addTokens(from, to, assetId, share, totalAssetShare, skim);
+        emit LogAddAsset(skim ? address(yieldBox) : from, to, share, fraction);
+    }
+
+    /// @dev Concrete implementation of `removeAsset`.
+    /// @param from The account to remove from. Should always be msg.sender except for `depositFeesToyieldBox()`.
+    function _removeAsset(address from, address to, uint256 fraction) private returns (uint256 share) {
+        if (totalAsset.base == 0) {
+            return 0;
+        }
+        Rebase memory _totalAsset = totalAsset;
+        uint256 allShare = _totalAsset.elastic + yieldBox.toShare(assetId, totalBorrow.elastic, false);
+        share = (fraction * allShare) / _totalAsset.base;
+
+        _totalAsset.base -= fraction.toUint128();
+        if (_totalAsset.base < 1000) revert MinLimit();
+
+        balanceOf[from] -= fraction;
+        emit Transfer(from, address(0), fraction);
+        _totalAsset.elastic -= share.toUint128();
+        totalAsset = _totalAsset;
+        emit LogRemoveAsset(from, to, share, fraction);
+        yieldBox.transfer(address(this), to, assetId, share);
     }
 
     receive() external payable {}

--- a/contracts/usdo/modules/UsdoOptionReceiverModule.sol
+++ b/contracts/usdo/modules/UsdoOptionReceiverModule.sol
@@ -161,7 +161,7 @@ contract UsdoOptionReceiverModule is BaseUsdo {
             }
 
             msg_.lzSendParams.sendParam = _send;
-            IOftSender(tapOft).sendPacket(msg_.lzSendParams, "");
+            IOftSender(tapOft).sendPacket{value: msg.value}(msg_.lzSendParams, "");
 
             // Refund extra amounts
             if (tapBalance - amountToSend > 0) {

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,7 @@ broadcast = 'gen/broadcast'
 solc_version='0.8.22'
 evm_version='paris'
 optimizer = true
-optimizer_runs = 30
+optimizer_runs = 10
 
 remappings = [
 	"solidity-bytes-utils/=node_modules/@layerzerolabs/solidity-bytes-utils/",

--- a/test/Usdo.t.sol
+++ b/test/Usdo.t.sol
@@ -1177,7 +1177,7 @@ contract UsdoTest is UsdoTestHelper {
                         prevData: bytes(""),
                         prevOptionsData: bytes("")
                     }),
-                    lzReceiveGas: 500_000,
+                    lzReceiveGas: 5_000_000,
                     lzReceiveValue: 0,
                     refundAddress: address(this)
                 })
@@ -1234,13 +1234,13 @@ contract UsdoTest is UsdoTestHelper {
                 msgType: PT_YB_SEND_SGL_LEND_OR_REPAY,
                 composeMsgData: ComposeMsgData({
                     index: 0,
-                    gas: 500_000,
+                    gas: 5_000_000,
                     value: uint128(withdrawMsgFee_.nativeFee),
                     data: marketMsg_,
                     prevData: bytes(""),
                     prevOptionsData: bytes("")
                 }),
-                lzReceiveGas: 500_000,
+                lzReceiveGas: 5_000_000,
                 lzReceiveValue: 0,
                 refundAddress: address(this)
             })

--- a/test/helpers/UsdoTestHelper.t.sol
+++ b/test/helpers/UsdoTestHelper.t.sol
@@ -11,6 +11,7 @@ import {IERC20} from "@boringcrypto/boring-solidity/contracts/libraries/BoringER
 // Tapioca
 import {SimpleLeverageExecutor} from "contracts/markets/leverage/SimpleLeverageExecutor.sol";
 import {ILeverageExecutor} from "tapioca-periph/interfaces/bar/ILeverageExecutor.sol";
+import {SGLInterestHelper} from "contracts/markets/singularity/SGLInterestHelper.sol";
 import {ITapiocaOracle} from "tapioca-periph/interfaces/periph/ITapiocaOracle.sol";
 import {ERC20WithoutStrategy} from "yieldbox/strategies/ERC20WithoutStrategy.sol";
 import {IZeroXSwapper} from "tapioca-periph/interfaces/periph/IZeroXSwapper.sol";
@@ -225,6 +226,21 @@ contract UsdoTestHelper is TestHelper, TestUtils {
         {
             _penrose.addSingularity(_mc, address(sgl));
         }
+
+        {
+            SGLInterestHelper sglInterestHelper = new SGLInterestHelper();
+
+            bytes memory payload = abi.encodeWithSelector(
+                Singularity.setSingularityConfig.selector, sgl.borrowOpeningFee(), 0, 0, 0, 0, 0, 0, address(sglInterestHelper)
+            );
+            address[] memory mc = new address[](1);
+            mc[0] = address(sgl);
+
+            bytes[] memory data = new bytes[](1);
+            data[0] = payload;
+            _penrose.executeMarketFn(mc, data, false);
+        }
+        
         return sgl;
     }
 

--- a/test/markets/Origins.t.sol
+++ b/test/markets/Origins.t.sol
@@ -144,7 +144,7 @@ contract OriginsTest is UsdoTestHelper {
             collateralYieldBoxId,
             ITapiocaOracle(address(oracle)),
             0,
-            95000
+            99999
         );
 
         vm.label(address(origins), "Origins");
@@ -238,6 +238,33 @@ contract OriginsTest is UsdoTestHelper {
         origins.updatePause(Market.PauseType.Borrow, true);
         vm.expectRevert("Market: paused");
         origins.borrow(1);
+    }
+
+    function test_origin_should_borrow_max() public {
+        uint256 collateralAmount = 1 ether;
+        uint256 borrowAmount = 9e17;
+
+        deal(address(collateral), address(this), collateralAmount);
+
+        depositCollateral(collateralAmount);
+
+        borrow(borrowAmount, false);
+    }
+
+    function test_origin_should_borrow_max_2000_ether() public {
+        uint256 collateralAmount = 1 ether;
+        uint256 borrowAmount = 1900e18;
+        
+        oracle.set(5e14);
+        origins.updateExchangeRate();
+
+        deal(address(collateral), address(this), collateralAmount);
+
+        depositCollateral(collateralAmount);
+
+        borrow(borrowAmount, false);
+
+        borrow(100e18, true);
     }
 
     function test_should_borrow_without_lenders() public {

--- a/test/markets/Singularity.t.sol
+++ b/test/markets/Singularity.t.sol
@@ -233,7 +233,7 @@ contract SingularityTest is UsdoTestHelper {
         uint256 interestElasticity = singularity.interestElasticity();
 
         bytes memory payload = abi.encodeWithSelector(
-            Singularity.setSingularityConfig.selector, singularity.borrowOpeningFee(), 0, 0, 0, 0, 0, 0
+            Singularity.setSingularityConfig.selector, singularity.borrowOpeningFee(), 0, 0, 0, 0, 0, 0, address(0)
         );
         address[] memory mc = new address[](1);
         mc[0] = address(singularity);
@@ -254,7 +254,7 @@ contract SingularityTest is UsdoTestHelper {
 
         uint256 toSetValue = 101;
         {
-            payload = abi.encodeWithSelector(Singularity.setSingularityConfig.selector, toSetValue, 0, 0, 0, 0, 0, 0);
+            payload = abi.encodeWithSelector(Singularity.setSingularityConfig.selector, toSetValue, 0, 0, 0, 0, 0, 0, address(0));
             data = new bytes[](1);
             data[0] = payload;
             penrose.executeMarketFn(mc, data, false);


### PR DESCRIPTION
- replaced some parts of the code with `assembly`
- removed some old state vars related to LiquidationQueue 
- removed `viewLiquidationCollateralAmount` public method from `SGLLiquidation` and moved it to `MarketHelper` since its purpose was to be a helper
- removed `_addAsset` and `_removeAsset` from `SGLCommon` and declared them as private in `Singularity` as there's the only place where they are used