### PR TITLE
GT_05-14-chore_removed__getrevertmsg_from_markethelper-merge-hotfix

### DIFF
--- a/contracts/markets/MarketHelper.sol
+++ b/contracts/markets/MarketHelper.sol
@@ -348,16 +348,4 @@ contract MarketHelper {
             }
         }
     }
-
-    function _getRevertMsg(bytes memory _returnData) internal pure returns (string memory) {
-        if (_returnData.length > 1000) return "Market: reason too long";
-        // If the _res length is less than 68, then the transaction failed silently (without a revert message)
-        if (_returnData.length < 68) return "Market: no return data";
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            // Slice the sighash.
-            _returnData := add(_returnData, 0x04)
-        }
-        return abi.decode(_returnData, (string)); // All that remains is the revert string
-    }
 }


### PR DESCRIPTION
chore: removed _getRevertMsg from MarketHelper

Merge remote-tracking branch 'origin/GT_05-14-chore_removed__getrevertmsg_from_markethelper' into GT_05-14-chore_removed__getrevertmsg_from_markethelper-merge-hotfix