### PR TITLE
deadrosez | [L-02] BaseLeverageExecutor does not verify that the actually swapped amount is the same as amountIn CU-86dth3q0e

### DIFF
--- a/contracts/markets/bigBang/BBLeverage.sol
+++ b/contracts/markets/bigBang/BBLeverage.sol
@@ -93,6 +93,7 @@ contract BBLeverage is BBLendingCommon {
         }
         {
             amountOut = leverageExecutor.getCollateral(
+                from,
                 address(asset),
                 address(collateral),
                 memoryData.supplyShareToAmount + memoryData.borrowShareToAmount,
@@ -144,7 +145,7 @@ contract BBLeverage is BBLendingCommon {
 
         (memoryData.leverageAmount,) =
             yieldBox.withdraw(collateralId, address(this), address(leverageExecutor), 0, share);
-        amountOut = leverageExecutor.getAsset(address(collateral), address(asset), memoryData.leverageAmount, data);
+        amountOut = leverageExecutor.getAsset(from, address(collateral), address(asset), memoryData.leverageAmount, data);
         memoryData.shareOut = yieldBox.toShare(assetId, amountOut, false);
         address(asset).safeApprove(address(yieldBox), type(uint256).max);
         yieldBox.depositAsset(assetId, address(this), from, 0, memoryData.shareOut); // TODO Check for rounding attack?

--- a/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
@@ -82,7 +82,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
      *
      * @inheritdoc BaseLeverageExecutor
      */
-    function getCollateral(address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
+    function getCollateral(address refundDustAddress, address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
         external
         payable
         override
@@ -99,7 +99,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
 
         // Swap asset with `SGlpLeverageSwapData.token`
         uint256 tokenAmount = _swapAndTransferToSender(
-            false, assetAddress, glpSwapData.token, assetAmountIn, abi.encode(glpSwapData.swapData)
+            refundDustAddress, false, assetAddress, glpSwapData.token, assetAmountIn, abi.encode(glpSwapData.swapData)
         );
 
         // Swap `SGlpLeverageSwapData.token` with GLP
@@ -120,7 +120,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
      *
      * @inheritdoc BaseLeverageExecutor
      */
-    function getAsset(address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
+    function getAsset(address refundDustAddress, address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
         external
         override
         returns (uint256 assetAmountOut)
@@ -142,7 +142,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
         // If sendBack true and swapData.swapperData.toftInfo.isTokenOutToft false
         // The asset will be transfer via IERC20 transfer.
         assetAmountOut = _swapAndTransferToSender(
-            true, tokenSwapData.token, assetAddress, tokenAmount, abi.encode(tokenSwapData.swapData)
+            refundDustAddress, true, tokenSwapData.token, assetAddress, tokenAmount, abi.encode(tokenSwapData.swapData)
         );
     }
 

--- a/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
@@ -37,7 +37,7 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
      * @dev Expects SLeverageSwapData.toftInfo.isTokenOutToft to be false. Does the wrapping internally.
      * @inheritdoc BaseLeverageExecutor
      */
-    function getCollateral(address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
+    function getCollateral(address refundDustAddress, address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
         external
         payable
         override
@@ -52,7 +52,7 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
         (address sDaiAddress, address daiAddress) = _getAddresses(collateralAddress);
 
         //swap USDO (asset) with DAI
-        uint256 daiAmount = _swapAndTransferToSender(false, assetAddress, daiAddress, assetAmountIn, data);
+        uint256 daiAmount = _swapAndTransferToSender(refundDustAddress, false, assetAddress, daiAddress, assetAmountIn, data);
 
         //obtain sDai
         daiAddress.safeApprove(sDaiAddress, daiAmount);
@@ -70,7 +70,7 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
      * @dev Expects SLeverageSwapData.toftInfo.isTokenOutToft to be false. Does the wrapping internally.
      * @inheritdoc BaseLeverageExecutor
      */
-    function getAsset(address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
+    function getAsset(address refundDustAddress, address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
         external
         override
         returns (uint256 assetAmountOut)
@@ -87,7 +87,7 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
         // swap DAI with USDO, and transfer to sender
         // If sendBack true and swapData.swapperData.toftInfo.isTokenOutToft false
         // The asset will be transfer via IERC20 transfer.
-        assetAmountOut = _swapAndTransferToSender(true, daiAddress, assetAddress, obtainedDai, data);
+        assetAmountOut = _swapAndTransferToSender(refundDustAddress, true, daiAddress, assetAddress, obtainedDai, data);
     }
 
     // ********************** //

--- a/contracts/markets/leverage/SimpleLeverageExecutor.sol
+++ b/contracts/markets/leverage/SimpleLeverageExecutor.sol
@@ -38,6 +38,7 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
      * @inheritdoc BaseLeverageExecutor
      */
     function getCollateral(
+        address refundDustAddress,
         address assetAddress,
         address collateralAddress,
         uint256 assetAmountIn,
@@ -45,13 +46,14 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
     ) external payable override returns (uint256 collateralAmountOut) {
         // Should be called only by approved SGL/BB markets.
         if (!cluster.isWhitelisted(0, msg.sender)) revert SenderNotValid();
-        return _swapAndTransferToSender(true, assetAddress, collateralAddress, assetAmountIn, swapperData);
+        return _swapAndTransferToSender(refundDustAddress, true, assetAddress, collateralAddress, assetAmountIn, swapperData);
     }
 
     /**
      * @inheritdoc BaseLeverageExecutor
      */
     function getAsset(
+        address refundDustAddress,
         address collateralAddress,
         address assetAddress,
         uint256 collateralAmountIn,
@@ -59,6 +61,6 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
     ) external override returns (uint256 assetAmountOut) {
         // Should be called only by approved SGL/BB markets.
         if (!cluster.isWhitelisted(0, msg.sender)) revert SenderNotValid();
-        return _swapAndTransferToSender(true, collateralAddress, assetAddress, collateralAmountIn, swapperData);
+        return _swapAndTransferToSender(refundDustAddress, true, collateralAddress, assetAddress, collateralAmountIn, swapperData);
     }
 }

--- a/contracts/markets/singularity/SGLLeverage.sol
+++ b/contracts/markets/singularity/SGLLeverage.sol
@@ -76,7 +76,7 @@ contract SGLLeverage is SGLLendingCommon {
         (uint256 borrowShareToAmount,) =
             yieldBox.withdraw(assetId, address(this), address(leverageExecutor), 0, borrowShare);
         amountOut = leverageExecutor.getCollateral(
-            address(asset), address(collateral), supplyShareToAmount + borrowShareToAmount, calldata_.data
+            from, address(asset), address(collateral), supplyShareToAmount + borrowShareToAmount, calldata_.data
         );
         uint256 collateralShare = yieldBox.toShare(collateralId, amountOut, false);
         if (collateralShare == 0) revert CollateralShareNotValid();
@@ -125,7 +125,7 @@ contract SGLLeverage is SGLLendingCommon {
         (uint256 leverageAmount,) =
             yieldBox.withdraw(collateralId, address(this), address(leverageExecutor), 0, calldata_.share);
 
-        amountOut = leverageExecutor.getAsset(address(collateral), address(asset), leverageAmount, calldata_.data);
+        amountOut = leverageExecutor.getAsset(from, address(collateral), address(asset), leverageAmount, calldata_.data);
         uint256 shareOut = yieldBox.toShare(assetId, amountOut, false);
 
         address(asset).safeApprove(address(yieldBox), type(uint256).max);

--- a/test/leverage/AssetToSDaiLeverageExecutor.t.sol
+++ b/test/leverage/AssetToSDaiLeverageExecutor.t.sol
@@ -115,7 +115,7 @@ contract AssetToSDaiLeverageExecutorTest is BaseLeverageExecutorTest {
         SLeverageSwapData memory swapData =
             SLeverageSwapData({minAmountOut: 0, toftInfo: toftInfo, swapperData: abi.encode(zeroXSwapData)});
 
-        executor.getCollateral(address(asset), address(toft), amountIn, abi.encode(swapData));
+        executor.getCollateral(address(this), address(asset), address(toft), amountIn, abi.encode(swapData));
 
         assertEq(toft.balanceOf(address(this)), amountIn);
     }
@@ -142,7 +142,7 @@ contract AssetToSDaiLeverageExecutorTest is BaseLeverageExecutorTest {
         SLeverageSwapData memory swapData =
             SLeverageSwapData({minAmountOut: 0, toftInfo: toftInfo, swapperData: abi.encode(zeroXSwapData)});
 
-        executor.getAsset(address(toft), address(asset), amountIn, abi.encode(swapData));
+        executor.getAsset(address(this), address(toft), address(asset), amountIn, abi.encode(swapData));
         assertEq(asset.balanceOf(address(this)), amountIn);
     }
 }

--- a/test/mocks/ZeroXSwapperMockTarget.sol
+++ b/test/mocks/ZeroXSwapperMockTarget.sol
@@ -19,4 +19,11 @@ contract ZeroXSwapperMockTarget {
     function transferTokens(address token, uint256 amount) public payable {
         IERC20(token).safeTransfer(msg.sender, amount);
     }
+
+    function transferTokensWithDust(address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut) public payable {
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+
+        IERC20(tokenOut).safeTransfer(msg.sender, amountOut);
+        IERC20(tokenIn).safeTransfer(msg.sender, amountIn-amountOut);
+    }
 }


### PR DESCRIPTION
patch(`Leverage executors`): refund dust to `from` if `amountIn` was not used entirely by the swapper [`86dth3q0e`] 
- Check swapped amount and refund if dust is left in the contract
- Added `refundDustAddress` param to LE getCollateral and getAsset

`GT_zerox-swapper-refund`

Periph linked PR:
https://github.com/Tapioca-DAO/tapioca-periph/pull/281