### PR TITLE
deadrosez | [M-02] AssetToSGLPLeverageExecutor returns collateralAmountOut prior to the wrapping and not actual received TOFT amount  CU-86dtgnh9f

### DIFF
--- a/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
@@ -108,7 +108,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
         // Wrap into tsGLP to sender
         address sGLP = ITOFT(collateralAddress).erc20();
         sGLP.safeApprove(collateralAddress, collateralAmountOut);
-        ITOFT(collateralAddress).wrap(address(this), msg.sender, collateralAmountOut);
+        collateralAmountOut = ITOFT(collateralAddress).wrap(address(this), msg.sender, collateralAmountOut);
         sGLP.safeApprove(collateralAddress, 0);
     }
 

--- a/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
@@ -60,7 +60,7 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
 
         // Wrap into tsDai to sender
         sDaiAddress.safeApprove(collateralAddress, collateralAmountOut);
-        ITOFT(collateralAddress).wrap(address(this), msg.sender, collateralAmountOut);
+        collateralAmountOut = ITOFT(collateralAddress).wrap(address(this), msg.sender, collateralAmountOut);
         sDaiAddress.safeApprove(collateralAddress, 0);
     }
 


### PR DESCRIPTION
fix(`L.E`): Track `amountOut` on `wrap()` [`86dtgnh9f`]