### PR TITLE
windhustler | [M-07] UsdoMarketReceiverModule.lendOrRepayReceiver repay flow is non-functional CU-86dtgzh2z

### DIFF
--- a/contracts/usdo/modules/UsdoMarketReceiverModule.sol
+++ b/contracts/usdo/modules/UsdoMarketReceiverModule.sol
@@ -71,18 +71,6 @@ contract UsdoMarketReceiverModule is BaseUsdo {
         */
         msg_ = _validateLendOrRepayReceiver(msg_);
 
-        /**
-        * @dev Pearlmit approvals
-        */
-        // approve(address(msg_.lendParams.magnetar), msg_.lendParams.depositAmount);
-        approve(address(pearlmit), msg_.lendParams.depositAmount);
-        pearlmit.approve(
-            address(this),
-            0,
-            msg_.lendParams.magnetar,
-            uint200(msg_.lendParams.depositAmount),
-            uint48(block.timestamp + 1)
-        );
 
         /**
         * @dev Lend or Repay through `magnetar`


### PR DESCRIPTION
fix(`UsdoMarketReceiverModule`): removed unneeded approvals from `lendOrRepayReceiver()` [`86dtgzh2z`]