### PR TITLE
deadrosez | [L-01] AssetTotsDaiLeverageExecutor minAmountOut check should be done on the sDAI received instead of on the DAI received  CU-86dtgnhaq

### DIFF
--- a/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
@@ -58,6 +58,10 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor {
         daiAddress.safeApprove(sDaiAddress, daiAmount);
         collateralAmountOut = ISavingsDai(sDaiAddress).deposit(daiAmount, address(this));
 
+        //re-check minAmount to verify the DAI<>sDAI ratio
+        SLeverageSwapData memory swapData = abi.decode(data, (SLeverageSwapData));
+        if (collateralAmountOut < swapData.minAmountOut) revert MinAmountNotValid(swapData.minAmountOut, collateralAmountOut);
+
         // Wrap into tsDai to sender
         sDaiAddress.safeApprove(collateralAddress, collateralAmountOut);
         collateralAmountOut = ITOFT(collateralAddress).wrap(address(this), msg.sender, collateralAmountOut);


### PR DESCRIPTION
fix(`AssetTotsDaiLeverageExecutor`): Check minAmountOut also against sDai amount on AssetToTsDaiLeverageExecutor since Dai <> sDai might not always be 1:1 [`86dtgnhaq`]