### PR TITLE
Use Pearlmit on TOB exerciseOption for oTAP approval  `CU-86dthzrv6`

### DIFF
--- a/contracts/usdo/modules/UsdoOptionReceiverModule.sol
+++ b/contracts/usdo/modules/UsdoOptionReceiverModule.sol
@@ -162,6 +162,13 @@ contract UsdoOptionReceiverModule is BaseUsdo {
             _options.tapAmount
         );
 
+        // Clear Pearlmit ERC721 allowance post execution
+        {
+            address oTap = ITapiocaOptionBroker(_options.target).oTAP();
+            address oTapOwner = IERC721(oTap).ownerOf(_options.oTAPTokenID);
+            pearlmit.clearAllowance(oTapOwner, oTap, _options.oTAPTokenID);
+        }
+
         uint256 bAfter = balanceOf(address(this));
 
         // Refund if less was used.


### PR DESCRIPTION
patch(`UsdoOptionReceiverModule`): Clear `Pearlmit->oTap` allowance post exercise in `_exerciseAndRefund()`  [`86dthzrv6`]