### PR TITLE
Remove the Pearlmit code from TOE transferFrom `CU-86dtj04d9`

### DIFF
--- a/contracts/usdo/Usdo.sol
+++ b/contracts/usdo/Usdo.sol
@@ -101,17 +101,6 @@ contract Usdo is BaseUsdo, Pausable, ReentrancyGuard, ERC20Permit {
     receive() external payable {}
 
     /**
-     * @inheritdoc BaseTapiocaOmnichainEngine
-     */
-    function transferFrom(address _from, address _to, uint256 _amount)
-        public
-        override(BaseTapiocaOmnichainEngine, ERC20)
-        returns (bool)
-    {
-        return BaseTapiocaOmnichainEngine.transferFrom(_from, _to, _amount);
-    }
-
-    /**
      * @dev Slightly modified version of the OFT _lzReceive() operation.
      * The composed message is sent to `address(this)` instead of `toAddress`.
      * @dev Internal function to handle the receive on the LayerZero endpoint.


### PR DESCRIPTION
fix(`Usdo`): Removed `transferFrom()` `TOE` override [`86dtj04d9`]
- Checked out `periph` submodule to `GT_86dtj04d9_Remove-the-Pearlmit-code-from-TOE-transferFrom`