### PR TITLE
Add `nonReentrant` to `TOE` functions `CU-86dtcykhr`

### DIFF
--- a/contracts/usdo/modules/UsdoReceiver.sol
+++ b/contracts/usdo/modules/UsdoReceiver.sol
@@ -9,10 +9,11 @@ import {OFT} from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol";
 
 // External
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 // Tapioca
-import {IUsdo, UsdoInitStruct} from "tapioca-periph/interfaces/oft/IUsdo.sol";
 import {TapiocaOmnichainReceiver} from "tapioca-periph/tapiocaOmnichainEngine/TapiocaOmnichainReceiver.sol";
+import {IUsdo, UsdoInitStruct} from "tapioca-periph/interfaces/oft/IUsdo.sol";
 import {UsdoMarketReceiverModule} from "./UsdoMarketReceiverModule.sol";
 import {UsdoOptionReceiverModule} from "./UsdoOptionReceiverModule.sol";
 import {UsdoReceiver} from "./UsdoReceiver.sol";
@@ -29,7 +30,7 @@ import {BaseUsdo} from "../BaseUsdo.sol";
    
 */
 
-contract UsdoReceiver is BaseUsdo, TapiocaOmnichainReceiver {
+contract UsdoReceiver is BaseUsdo, TapiocaOmnichainReceiver, ReentrancyGuard {
     using OFTMsgCodec for bytes;
     using OFTMsgCodec for bytes32;
     using SafeERC20 for IERC20;
@@ -57,6 +58,7 @@ contract UsdoReceiver is BaseUsdo, TapiocaOmnichainReceiver {
     function _toeComposeReceiver(uint16 _msgType, address _srcChainSender, bytes memory _toeComposeMsg)
         internal
         override
+        nonReentrant
         returns (bool success)
     {
         if (_msgType == MSG_TAP_EXERCISE) {


### PR DESCRIPTION
patch(`UsdoReceiver`): Add `nonReentrant` to `_toeComposeReceiver()` [`86dtcykhr`]