### PR TITLE
Not properly tracking debt accrual leads `mintOpenInterestDebt()` to lose `twTap` rewards `CU-86dtm99eu`

### DIFF
--- a/contracts/Penrose.sol
+++ b/contracts/Penrose.sol
@@ -232,7 +232,7 @@ contract Penrose is Ownable, PearlmitHandler {
         for (uint256 i; i < len; i++) {
             IBigBang market = IBigBang(allBigBangMarkets[i]);
             if (isMarketRegistered[address(market)]) {
-                _totalUsdoDebt += market.viewOpenInterest();
+                _totalUsdoDebt += market.openInterestDebt();
             }
         }
 
@@ -322,7 +322,7 @@ contract Penrose is Ownable, PearlmitHandler {
         for (uint256 i; i < len; i++) {
             IBigBang market = IBigBang(allBigBangMarkets[i]);
             if (isMarketRegistered[address(market)]) {
-                sum += market.computeOpenInterestMintable();
+                sum += market.consumeMintableOpenInterestDebt();
             }
         }
 

--- a/contracts/markets/bigBang/BBCommon.sol
+++ b/contracts/markets/bigBang/BBCommon.sol
@@ -111,7 +111,7 @@ contract BBCommon is BBStorage {
             extraAmount = max;
         }
         _totalBorrow.elastic += extraAmount.toUint128();
-        openInterestsDebt += extraAmount;
+        openInterestDebt += extraAmount;
 
         totalBorrow = _totalBorrow;
         accrueInfo = _accrueInfo;

--- a/contracts/markets/bigBang/BBCommon.sol
+++ b/contracts/markets/bigBang/BBCommon.sol
@@ -111,6 +111,7 @@ contract BBCommon is BBStorage {
             extraAmount = max;
         }
         _totalBorrow.elastic += extraAmount.toUint128();
+        openInterestsDebt += extraAmount;
 
         totalBorrow = _totalBorrow;
         accrueInfo = _accrueInfo;

--- a/contracts/markets/bigBang/BBStorage.sol
+++ b/contracts/markets/bigBang/BBStorage.sol
@@ -53,7 +53,7 @@ contract BBStorage is Ownable, Market, ReentrancyGuard {
 
     uint256 internal constant DEBT_PRECISION = 1e18;
 
-    uint256 public openInterestsDebt;
+    uint256 public openInterestDebt;
 
     // ************** //
     // *** EVENTS *** //

--- a/contracts/markets/bigBang/BBStorage.sol
+++ b/contracts/markets/bigBang/BBStorage.sol
@@ -51,9 +51,9 @@ contract BBStorage is Ownable, Market, ReentrancyGuard {
     uint256 public maxMintFeeStart;
     uint256 public minMintFeeStart;
 
-    uint256 public debtMinted;
-
     uint256 internal constant DEBT_PRECISION = 1e18;
+
+    uint256 public openInterestsDebt;
 
     // ************** //
     // *** EVENTS *** //

--- a/contracts/markets/bigBang/BigBang.sol
+++ b/contracts/markets/bigBang/BigBang.sol
@@ -198,16 +198,6 @@ contract BigBang is MarketStateView, BBCommon {
     // ************************ //
     // *** PUBLIC FUNCTIONS *** //
     // ************************ //
-    /// @notice returns open interest debt
-    /// @dev accrue needs to be called before
-    function viewOpenInterest() public view returns (uint256) {
-        uint256 debt = totalBorrow.elastic - totalBorrow.base;
-        if (debtMinted > debt) {
-            return 0;
-        }
-
-        return debt - debtMinted;
-    }
 
     /// @notice Allows batched call to BingBang.
     /// @param calls An array encoded call data.
@@ -236,16 +226,12 @@ contract BigBang is MarketStateView, BBCommon {
     // ************************* //
     // *** OWNER FUNCTIONS ***** //
     // ************************* //
-    /// @notice computes mintable debt and updates `debtMinted`
-    function computeOpenInterestMintable() external onlyOwner returns (uint256) {
-        _accrue();
-        uint256 toMint = viewOpenInterest();
-        if (toMint == 0) {
-            // Round down to not over mint
-            debtMinted = totalBorrow.toBase(totalBorrow.elastic, false) - totalBorrow.base;
-        }
-        debtMinted += toMint;
-        return toMint;
+
+    /// @notice Reset the open interest debt and return the value
+    function consumeMintableOpenInterestDebt() external onlyOwner returns (uint256) {
+        uint256 _openInterestsDebt = openInterestsDebt;
+        openInterestsDebt = 0;
+        return _openInterestsDebt;
     }
 
     /// @notice updates the pause state of the contract

--- a/contracts/markets/bigBang/BigBang.sol
+++ b/contracts/markets/bigBang/BigBang.sol
@@ -229,9 +229,9 @@ contract BigBang is MarketStateView, BBCommon {
 
     /// @notice Reset the open interest debt and return the value
     function consumeMintableOpenInterestDebt() external onlyOwner returns (uint256) {
-        uint256 _openInterestsDebt = openInterestsDebt;
-        openInterestsDebt = 0;
-        return _openInterestsDebt;
+        uint256 _openInterestDebt = openInterestDebt;
+        openInterestDebt = 0;
+        return _openInterestDebt;
     }
 
     /// @notice updates the pause state of the contract

--- a/contracts/markets/bigBang/BigBang.sol
+++ b/contracts/markets/bigBang/BigBang.sol
@@ -241,7 +241,8 @@ contract BigBang is MarketStateView, BBCommon {
         _accrue();
         uint256 toMint = viewOpenInterest();
         if (toMint == 0) {
-            debtMinted = totalBorrow.elastic - totalBorrow.base;
+            // Round down to not over mint
+            debtMinted = totalBorrow.toBase(totalBorrow.elastic, false) - totalBorrow.base;
         }
         debtMinted += toMint;
         return toMint;


### PR DESCRIPTION
patch(`BigBang`): Converting `elastic` unit to `base` in `computeOpenInterestMintable()` [`86dtm99eu`]