### PR TITLE
0xAdrii | AssetTotsDaiLeverageExecutor and SimpleLeverageExecutor are not pausable, although AssetToSGLPLeverageExecutor is #13 [`CU-86dtnbhtx`]

### DIFF
--- a/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
@@ -135,7 +135,7 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
         address assetAddress,
         uint256 collateralAmountIn,
         bytes calldata data
-    ) external override returns (uint256 assetAmountOut) {
+    ) external override whenNotPaused returns (uint256 assetAmountOut) {
         // Should be called only by approved SGL/BB markets.
         if (!cluster.isWhitelisted(0, msg.sender)) revert SenderNotValid();
 

--- a/contracts/markets/leverage/SimpleLeverageExecutor.sol
+++ b/contracts/markets/leverage/SimpleLeverageExecutor.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.22;
 
+// External
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
+
 // Tapioca
 import {IZeroXSwapper} from "tapioca-periph/interfaces/periph/IZeroXSwapper.sol";
 import {IWeth9} from "tapioca-periph/interfaces/external/weth/IWeth9.sol";
@@ -20,7 +23,7 @@ import {SafeApprove} from "../../libraries/SafeApprove.sol";
    
 */
 
-contract SimpleLeverageExecutor is BaseLeverageExecutor {
+contract SimpleLeverageExecutor is BaseLeverageExecutor, Pausable {
     using SafeApprove for address;
 
     // ************** //
@@ -30,6 +33,20 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
     constructor(IZeroXSwapper _swapper, ICluster _cluster, address _weth, IPearlmit _pearlmit)
         BaseLeverageExecutor(_swapper, _cluster, _weth, _pearlmit)
     {}
+
+    // ********************** //
+    // *** OWNER METHODS *** //
+    // ********************** //
+    /**
+     * @notice Un/Pauses this contract.
+     */
+    function setPause(bool _pauseState) external onlyOwner {
+        if (_pauseState) {
+            _pause();
+        } else {
+            _unpause();
+        }
+    }
 
     // ********************* //
     // *** PUBLIC METHODS *** //
@@ -44,7 +61,7 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
         address collateralAddress,
         uint256 assetAmountIn,
         bytes calldata swapperData
-    ) external payable override returns (uint256 collateralAmountOut) {
+    ) external payable override whenNotPaused returns (uint256 collateralAmountOut) {
         // Should be called only by approved SGL/BB markets.
         if (!cluster.isWhitelisted(0, msg.sender)) revert SenderNotValid();
         return _swapAndTransferToSender(
@@ -61,7 +78,7 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor {
         address assetAddress,
         uint256 collateralAmountIn,
         bytes calldata swapperData
-    ) external override returns (uint256 assetAmountOut) {
+    ) external override whenNotPaused returns (uint256 assetAmountOut) {
         // Should be called only by approved SGL/BB markets.
         if (!cluster.isWhitelisted(0, msg.sender)) revert SenderNotValid();
         return _swapAndTransferToSender(

--- a/contracts/usdo/Usdo.sol
+++ b/contracts/usdo/Usdo.sol
@@ -184,7 +184,7 @@ contract Usdo is BaseUsdo, Pausable, ReentrancyGuard, ERC20Permit {
         whenNotPaused
         returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
     {
-        this.send(_sendParam, _fee, _refundAddress);
+        (msgReceipt, oftReceipt) = this.send(_sendParam, _fee, _refundAddress);
     }
 
     /// =====================

--- a/test/leverage/AssetToSDaiLeverageExecutor.t.sol
+++ b/test/leverage/AssetToSDaiLeverageExecutor.t.sol
@@ -45,7 +45,7 @@ contract AssetToSDaiLeverageExecutorTest is BaseLeverageExecutorTest {
     ZeroXSwapper swapper;
 
     function setUp() public {
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
         {
             dai = new ERC20Mock("DAI", "DAI");
             vm.label(address(dai), "dai");

--- a/test/leverage/AssetToSGLPLeverageExecutor.t.sol
+++ b/test/leverage/AssetToSGLPLeverageExecutor.t.sol
@@ -54,7 +54,7 @@ contract AssetToSGLPLeverageExecutorTest is BaseLeverageExecutorTest {
     GmxMarketMock gmxMock;
 
     function setUp() public {
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
         {
             weth = new ERC20Mock("weth", "weth");
             vm.label(address(weth), "weth");

--- a/test/markets/BigBang.t.sol
+++ b/test/markets/BigBang.t.sol
@@ -99,7 +99,7 @@ contract BigBangTest is UsdoTestHelper {
         vm.label(userA, "userA");
         vm.label(userB, "userB");
 
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
         {
             tapOFT = new ERC20Mock("Tapioca OFT", "TAP");
             vm.label(address(tapOFT), "tapOFT");

--- a/test/markets/Origins.t.sol
+++ b/test/markets/Origins.t.sol
@@ -78,7 +78,7 @@ contract OriginsTest is UsdoTestHelper {
         vm.label(userA, "userA");
         vm.label(userB, "userB");
 
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
         {
             tapOFT = new ERC20Mock("Tapioca OFT", "TAP");
             vm.label(address(tapOFT), "tapOFT");

--- a/test/markets/Singularity.t.sol
+++ b/test/markets/Singularity.t.sol
@@ -97,7 +97,7 @@ contract SingularityTest is UsdoTestHelper {
         vm.label(userA, "userA");
         vm.label(userB, "userB");
 
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
         {
             tapOFT = new ERC20Mock("Tapioca OFT", "TAP");
             vm.label(address(tapOFT), "tapOFT");


### PR DESCRIPTION
- added `whenNotPaused` to `getCollateral` and `getAsset` on LEs
- fixed `USDO` compilation warnings by assigning return value in send method
- fixed compilation errors on tests