### PR TITLE
indexed Keyword in Events Causes Data Loss for Dynamic Array Variables [`86dtrqfrd`]

### DIFF
--- a/contracts/Penrose.sol
+++ b/contracts/Penrose.sol
@@ -136,7 +136,7 @@ contract Penrose is Ownable, PearlmitHandler {
     // *** EVENTS *** //
     // ************** //
     /// @notice event emitted when fees are extracted
-    event ProtocolWithdrawal(IMarket[] indexed markets, uint256 indexed timestamp);
+    event ProtocolWithdrawal(IMarket[] markets, uint256 indexed timestamp);
     /// @notice event emitted when Singularity master contract is registered
     event RegisterSingularityMasterContract(address indexed location, IPenrose.ContractType indexed risk);
     /// @notice event emitted when BigBang master contract is registered


### PR DESCRIPTION
chore(`events`): removed `indexed` from array element [`86dtrqfrd`]

Merge remote-tracking branch 'origin/GT_86dtrqfrd_indexed-Keyword-in-Events-Causes-Data-Loss-for-Dynamic-Array-Variables' into GT_backup-GT_86dtrqfrd_indexed-Keyword-in-Events-Causes-Data-Loss-for-Dynamic-Array-Variables