### PR TITLE
cergyk | MarketERC20::permit lacks of access control, enabling xChain calls relying on permits to be DoSed [`CU-86dtrqfpp`]

### DIFF
--- a/contracts/markets/Market.sol
+++ b/contracts/markets/Market.sol
@@ -51,8 +51,6 @@ abstract contract Market is MarketERC20, Ownable {
 
     /// @notice returns YieldBox address
     IYieldBox internal yieldBox;
-    /// @notice returns Penrose address
-    IPenrose internal penrose;
 
     IPearlmit internal pearlmit;
 
@@ -295,25 +293,6 @@ abstract contract Market is MarketERC20, Ownable {
     // ********************** //
     // *** VIEW FUNCTIONS *** //
     // ********************** //
-    /// @notice returns the maximum liquidatable amount for user
-    /// @param borrowPart amount borrowed
-    /// @param collateralPartInAsset collateral's value in borrowed asset
-    /// @param ratesPrecision collateralizationRate and liquidationCollateralizationRate precision
-    function computeClosingFactor(uint256 borrowPart, uint256 collateralPartInAsset, uint256 ratesPrecision)
-        public
-        view
-        returns (uint256)
-    {
-        return _computeClosingFactor(
-            borrowPart,
-            collateralPartInAsset,
-            ratesPrecision,
-            liquidationCollateralizationRate,
-            liquidationMultiplier,
-            totalBorrow
-        );
-    }
-
     function _computeClosingFactor(
         uint256 borrowPart,
         uint256 collateralPartInAsset,
@@ -321,7 +300,7 @@ abstract contract Market is MarketERC20, Ownable {
         uint256 _liquidationCollateralizationRate,
         uint256 _liquidationMultiplier,
         Rebase memory _totalBorrow
-    ) internal view returns (uint256) {
+    ) internal pure returns (uint256) {
         // Obviously it's not `borrowPart` anymore but `borrowAmount`
         borrowPart = (borrowPart * _totalBorrow.elastic) / _totalBorrow.base;
 
@@ -334,7 +313,7 @@ abstract contract Market is MarketERC20, Ownable {
         //compute numerator
         uint256 numerator = borrowPart - liquidationStartsAt;
         //compute denominator
-        uint256 diff = (liquidationCollateralizationRate * ((10 ** ratesPrecision) + _liquidationMultiplier))
+        uint256 diff = (_liquidationCollateralizationRate * ((10 ** ratesPrecision) + _liquidationMultiplier))
             / (10 ** ratesPrecision);
         int256 denominator = (int256(10 ** ratesPrecision) - int256(diff)) * int256(1e13);
 

--- a/contracts/markets/MarketERC20.sol
+++ b/contracts/markets/MarketERC20.sol
@@ -7,6 +7,10 @@ import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Re
 import {EIP712, ECDSA} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {IERC20} from "@boringcrypto/boring-solidity/contracts/ERC20.sol";
 
+// Tapioca
+import {IPenrose} from "tapioca-periph/interfaces/bar/IPenrose.sol";
+import {ICluster} from "tapioca-periph/interfaces/periph/ICluster.sol";
+
 /*
 
 ████████╗ █████╗ ██████╗ ██╗ ██████╗  ██████╗ █████╗ 
@@ -22,6 +26,10 @@ contract MarketERC20 is IERC20, IERC20Permit, IERC1155Receiver, EIP712 {
     // ************ //
     // *** VARS *** //
     // ************ //
+
+    /// @notice returns Penrose address
+    IPenrose internal penrose;
+
 
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 private constant _PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
@@ -206,6 +214,8 @@ contract MarketERC20 is IERC20, IERC20Permit, IERC1155Receiver, EIP712 {
         bytes32 s
     ) internal {
         require(block.timestamp <= deadline, "ERC20Permit: expired deadline");
+
+        if (!ICluster(penrose.cluster()).isWhitelisted(0, msg.sender)) require (owner == msg.sender, "MarketERC20: not authorized");
 
         bytes32 structHash;
 

--- a/contracts/markets/bigBang/BBLiquidation.sol
+++ b/contracts/markets/bigBang/BBLiquidation.sol
@@ -190,7 +190,7 @@ contract BBLiquidation is BBCommon {
 
         // compute closing factor (liquidatable amount)
         uint256 borrowPartWithBonus =
-            computeClosingFactor(userBorrowPart[user], collateralPartInAsset, FEE_PRECISION_DECIMALS);
+            _computeClosingFactor(userBorrowPart[user], collateralPartInAsset, FEE_PRECISION_DECIMALS, liquidationCollateralizationRate, liquidationMultiplier, totalBorrow);
 
         // limit liquidable amount before bonus to the current debt
         uint256 userTotalBorrowAmount = totalBorrow.toElastic(userBorrowPart[user], true);

--- a/test/Usdo.t.sol
+++ b/test/Usdo.t.sol
@@ -1058,6 +1058,8 @@ contract UsdoTest is UsdoTestHelper {
             approvalMsg_ = usdoHelper.buildMarketPermitApprovalMsg(permitApproval_);
         }
 
+        cluster.updateContract(0, address(bUsdo), true);
+
         PrepareLzCallReturn memory prepareLzCallReturn_ = usdoHelper.prepareLzCall(
             IUsdo(address(aUsdo)),
             PrepareLzCallData({
@@ -1126,6 +1128,8 @@ contract UsdoTest is UsdoTestHelper {
 
             approvalMsg_ = usdoHelper.buildMarketPermitApprovalMsg(permitApproval_);
         }
+
+        cluster.updateContract(0, address(bUsdo), true);
 
         PrepareLzCallReturn memory prepareLzCallReturn_ = usdoHelper.prepareLzCall(
             IUsdo(address(aUsdo)),


### PR DESCRIPTION
patch(`MarketERC20`): updated `permit` from `MarketERC20` to use either `msg.sender` or `from` if sender is whitelised [`86dtrqfpp`]

Merge remote-tracking branch 'origin/GT_86dtrqfpp_cergyk--MarketERC20permit-lacks-of-access-control' into GT_backup-GT_86dtrqfpp_cergyk--MarketERC20permit-lacks-of-access-control