### PR TITLE
BBLiquidation::_updateBorrowAndCollateralShare Liquidator can avoid having his bonus reduced when position is close to bad-debt [`CU-86dtrt1k4`]

### DIFF
--- a/contracts/markets/bigBang/BBLiquidation.sol
+++ b/contracts/markets/bigBang/BBLiquidation.sol
@@ -231,6 +231,8 @@ contract BBLiquidation is BBCommon {
                 revert InsufficientLiquidationBonus();
             }
         } else {
+            uint totalUserBorrowWithBonus = userTotalBorrowAmount + (userTotalBorrowAmount * liquidationBonusAmount) / FEE_PRECISION;
+            if (collateralPartInAsset < totalUserBorrowWithBonus) revert BadDebt();
             collateralShare =
                 yieldBox.toShare(collateralId, (borrowPartWithBonus * _exchangeRate) / EXCHANGE_RATE_PRECISION, false);
             if (collateralShare > userCollateralShare[user]) {

--- a/contracts/markets/singularity/SGLLiquidation.sol
+++ b/contracts/markets/singularity/SGLLiquidation.sol
@@ -258,6 +258,8 @@ contract SGLLiquidation is SGLCommon {
                 revert InsufficientLiquidationBonus();
             }
         } else {
+            uint totalUserBorrowWithBonus = userTotalBorrowAmount + (userTotalBorrowAmount * liquidationBonusAmount) / FEE_PRECISION;
+            if (collateralPartInAsset < totalUserBorrowWithBonus) revert BadDebt();
             collateralShare =
                 yieldBox.toShare(collateralId, (borrowPartWithBonus * _exchangeRate) / EXCHANGE_RATE_PRECISION, false);
             if (collateralShare > _userCollateralShare) {

--- a/test/markets/BigBang.t.sol
+++ b/test/markets/BigBang.t.sol
@@ -539,7 +539,7 @@ contract BigBangTest is UsdoTestHelper {
     }
 
     function test_borrow_and_liquidate() public {
-        uint256 collateralAmount = 1 ether;
+        uint256 collateralAmount = 1.2 ether;
         uint256 borrowAmount = 5e17;
 
         {


### PR DESCRIPTION
patch(`liquidation`): check for `BadDebt` in all cases [`86dtrt1k4`]

Merge remote-tracking branch 'origin/GT_86dtrt1k4_BBLiquidation_updateBorrowAndCollateralShare-Liquidator' into GT_backup-GT_86dtrt1k4_BBLiquidation_updateBorrowAndCollateralShare-Liquidator