### PR TITLE
Add conservator role to all pausable contracts [`CU-86dtt5qep`]

### DIFF
--- a/contracts/markets/Market.sol
+++ b/contracts/markets/Market.sol
@@ -45,9 +45,6 @@ abstract contract Market is MarketERC20, Ownable {
 
     /// @notice pause options
     mapping(PauseType pauseProp => bool pauseStatus) internal pauseOptions;
-    /// @notice conservator's addresss
-    /// @dev conservator can pause/unpause the contract
-    address internal conservator;
 
     /// @notice returns YieldBox address
     IYieldBox internal yieldBox;
@@ -202,7 +199,6 @@ abstract contract Market is MarketERC20, Ownable {
     /// @dev values are updated only if > 0 or not address(0)
     /// @param _oracle oracle address
     /// @param _oracleData oracle data
-    /// @param _conservator conservator address; conservator is allowed to pause/unpause the contract
     /// @param _protocolFee protocol fee percentage
     /// @param _liquidationBonusAmount extra amount factored in the closing factor computation
     /// @param _minLiquidatorReward minimum reward percentage a liquidator can receive
@@ -213,7 +209,6 @@ abstract contract Market is MarketERC20, Ownable {
     function setMarketConfig(
         ITapiocaOracle _oracle,
         bytes calldata _oracleData,
-        address _conservator,
         uint256 _protocolFee,
         uint256 _liquidationBonusAmount,
         uint256 _minLiquidatorReward,
@@ -229,11 +224,6 @@ abstract contract Market is MarketERC20, Ownable {
         if (_oracleData.length > 0) {
             oracleData = _oracleData;
             emit OracleDataUpdated();
-        }
-
-        if (_conservator != address(0)) {
-            emit ConservatorUpdated(conservator, _conservator);
-            conservator = _conservator;
         }
 
         if (_protocolFee > 0) {

--- a/contracts/markets/MarketStateView.sol
+++ b/contracts/markets/MarketStateView.sol
@@ -23,10 +23,6 @@ abstract contract MarketStateView is Market {
         return pauseOptions[_pauseProp];
     }
 
-    function _conservator() external view returns (address) {
-        return conservator;
-    }
-
     function _penrose() external view returns (address) {
         return address(penrose);
     }

--- a/contracts/markets/bigBang/BigBang.sol
+++ b/contracts/markets/bigBang/BigBang.sol
@@ -192,7 +192,6 @@ contract BigBang is MarketStateView, BBCommon {
         leverageExecutor = _leverageExecutor;
 
         _transferOwnership(address(penrose));
-        conservator = address(penrose);
     }
 
     // ************************ //
@@ -243,7 +242,7 @@ contract BigBang is MarketStateView, BBCommon {
     /// @dev can only be called by the conservator
     /// @param val the new value
     function updatePause(PauseType _type, bool val) external {
-        require(msg.sender == conservator, "Market: unauthorized");
+        require(penrose.cluster().hasRole(msg.sender, keccak256("PAUSABLE")) || msg.sender == owner(), "Market: unauthorized");
         require(val != pauseOptions[_type], "Market: same state");
         emit PausedUpdated(_type, pauseOptions[_type], val);
         pauseOptions[_type] = val;
@@ -252,7 +251,7 @@ contract BigBang is MarketStateView, BBCommon {
     /// @notice updates the pause state of the contract for all types
     /// @param val the new val
     function updatePauseAll(bool val) external {
-        require(msg.sender == conservator, "Market: unauthorized");
+        require(penrose.cluster().hasRole(msg.sender, keccak256("PAUSABLE")) || msg.sender == owner(), "Market: unauthorized");
 
         pauseOptions[PauseType.Borrow] = val;
         pauseOptions[PauseType.Repay] = val;

--- a/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetToSGLPLeverageExecutor.sol
@@ -69,7 +69,8 @@ contract AssetToSGLPLeverageExecutor is BaseLeverageExecutor, Pausable {
     /**
      * @notice Un/Pauses this contract.
      */
-    function setPause(bool _pauseState) external onlyOwner {
+    function setPause(bool _pauseState) external {
+        if (!cluster.hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert NotAuthorized();
         if (_pauseState) {
             _pause();
         } else {

--- a/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
+++ b/contracts/markets/leverage/AssetTotsDaiLeverageExecutor.sol
@@ -39,7 +39,8 @@ contract AssetTotsDaiLeverageExecutor is BaseLeverageExecutor, Pausable {
     /**
      * @notice Un/Pauses this contract.
      */
-    function setPause(bool _pauseState) external onlyOwner {
+    function setPause(bool _pauseState) external {
+        if (!cluster.hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert NotAuthorized();
         if (_pauseState) {
             _pause();
         } else {

--- a/contracts/markets/leverage/BaseLeverageExecutor.sol
+++ b/contracts/markets/leverage/BaseLeverageExecutor.sol
@@ -51,6 +51,7 @@ abstract contract BaseLeverageExecutor is Ownable {
     IWeth9 public weth;
 
     event AddressUpdated(address indexed oldAddr, address indexed newAddr);
+    event ConservatorUpdated(address indexed old, address indexed _new);
 
     // ************** //
     // *** ERRORS *** //
@@ -63,6 +64,7 @@ abstract contract BaseLeverageExecutor is Ownable {
     error TokenNotValid();
     error NativeNotSupported();
     error AddressNotValid();
+    error NotAuthorized();
 
     constructor(IZeroXSwapper _swapper, ICluster _cluster, address _weth, IPearlmit _pearlmit) {
         if (address(_cluster) == address(0)) revert AddressNotValid();
@@ -77,6 +79,9 @@ abstract contract BaseLeverageExecutor is Ownable {
     // ******************** //
     // *** OWNER METHODS *** //
     // ******************** //
+    /**
+     * @notice Sets the WETH address
+     */
     function setWeth(address _weth) external onlyOwner {
         emit AddressUpdated(address(weth), _weth);
         weth = IWeth9(_weth);

--- a/contracts/markets/leverage/SimpleLeverageExecutor.sol
+++ b/contracts/markets/leverage/SimpleLeverageExecutor.sol
@@ -40,7 +40,8 @@ contract SimpleLeverageExecutor is BaseLeverageExecutor, Pausable {
     /**
      * @notice Un/Pauses this contract.
      */
-    function setPause(bool _pauseState) external onlyOwner {
+    function setPause(bool _pauseState) external {
+        if (!cluster.hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert NotAuthorized();
         if (_pauseState) {
             _pause();
         } else {

--- a/contracts/markets/singularity/Singularity.sol
+++ b/contracts/markets/singularity/Singularity.sol
@@ -200,7 +200,6 @@ contract Singularity is MarketStateView, SGLCommon {
         }
 
         EXCHANGE_RATE_PRECISION = _exchangeRatePrecision > 0 ? _exchangeRatePrecision : 1e18;
-        conservator = owner();
     }
 
     // ************************ //
@@ -270,7 +269,7 @@ contract Singularity is MarketStateView, SGLCommon {
     /// @dev can only be called by the conservator
     /// @param val the new value
     function updatePause(PauseType _type, bool val, bool resetAccrueTimestmap) external {
-        if (msg.sender != conservator) revert NotAuthorized();
+        if (!penrose.cluster().hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert NotAuthorized();
         if (val == pauseOptions[_type]) revert SameState();
         emit PausedUpdated(_type, pauseOptions[_type], val);
         pauseOptions[_type] = val;

--- a/contracts/usdo/Usdo.sol
+++ b/contracts/usdo/Usdo.sol
@@ -69,6 +69,9 @@ contract Usdo is BaseUsdo, Pausable, ReentrancyGuard, ERC20Permit {
 
     event SetMinterStatus(address indexed _for, bool _status);
     event SetBurnerStatus(address indexed _for, bool _status);
+    event ConservatorUpdated(address indexed old, address indexed _new);
+
+    error AddressNotValid();
 
     constructor(UsdoInitStruct memory _initData, UsdoModulesInitStruct memory _modulesData)
         BaseUsdo(_initData)
@@ -308,7 +311,8 @@ contract Usdo is BaseUsdo, Pausable, ReentrancyGuard, ERC20Permit {
     /**
      * @notice Un/Pauses this contract.
      */
-    function setPause(bool _pauseState) external onlyOwner {
+    function setPause(bool _pauseState) external {
+        if (!getCluster().hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert Usdo_NotAuthorized();
         if (_pauseState) {
             _pause();
         } else {

--- a/test/Penrose.t.sol
+++ b/test/Penrose.t.sol
@@ -208,8 +208,7 @@ contract PenroseTest is UsdoTestHelper {
     }
 
     function test_penrose_should_not_withdraw_when_paused() public {
-        penrose.setConservator(address(this));
-        penrose.updatePause(true);
+        penrose.setPause(true);
 
         IMarket[] memory markets = new IMarket[](1);
         markets[0] = IMarket(address(0));

--- a/test/helpers/UsdoTestHelper.t.sol
+++ b/test/helpers/UsdoTestHelper.t.sol
@@ -144,7 +144,8 @@ contract UsdoTestHelper is TestHelper, TestUtils {
         uint256 collateralId,
         ITapiocaOracle oracle,
         uint256 exchangePrecision,
-        uint256 collateralizationRate
+        uint256 collateralizationRate,
+        address penrose
     ) public returns (Origins) {
         return new Origins(
             owner,
@@ -155,7 +156,8 @@ contract UsdoTestHelper is TestHelper, TestUtils {
             collateralId,
             oracle,
             exchangePrecision,
-            collateralizationRate
+            collateralizationRate,
+            IPenrose(penrose)
         );
     }
 

--- a/test/markets/BigBang.t.sol
+++ b/test/markets/BigBang.t.sol
@@ -448,7 +448,6 @@ contract BigBangTest is UsdoTestHelper {
                 Market.setMarketConfig.selector,
                 toSetAddress,
                 "",
-                toSetAddress,
                 toSetValue,
                 toSetValue,
                 toSetValue,
@@ -467,7 +466,6 @@ contract BigBangTest is UsdoTestHelper {
 
         {
             assertEq(address(bigBang._oracle()), address(toSetAddress));
-            assertEq(bigBang._conservator(), toSetAddress);
             assertEq(bigBang._protocolFee(), toSetValue);
             assertEq(bigBang._minLiquidatorReward(), toSetValue);
             assertEq(bigBang._maxLiquidatorReward(), toSetMaxValue);
@@ -485,11 +483,12 @@ contract BigBangTest is UsdoTestHelper {
 
     function test_should_not_work_when_paused() public {
         {
+            ICluster _cl = penrose.cluster();
+            _cl.setRoleForContract(address(this), keccak256("PAUSABLE"), true);
             bytes memory payload = abi.encodeWithSelector(
                 Market.setMarketConfig.selector,
                 address(0),
                 "",
-                address(this), //conservator
                 0,
                 0,
                 0,

--- a/test/markets/Origins.t.sol
+++ b/test/markets/Origins.t.sol
@@ -145,7 +145,8 @@ contract OriginsTest is UsdoTestHelper {
             collateralYieldBoxId,
             ITapiocaOracle(address(oracle)),
             0,
-            99999
+            99999,
+            address(penrose)
         );
 
         vm.label(address(origins), "Origins");
@@ -186,7 +187,6 @@ contract OriginsTest is UsdoTestHelper {
             origins.setMarketConfig(
                 ITapiocaOracle(toSetAddress),
                 "",
-                toSetAddress,
                 toSetValue,
                 toSetValue,
                 toSetValue,
@@ -199,7 +199,6 @@ contract OriginsTest is UsdoTestHelper {
 
         {
             assertEq(address(origins._oracle()), address(toSetAddress));
-            assertEq(origins._conservator(), toSetAddress);
             assertEq(origins._protocolFee(), toSetValue);
             assertEq(origins._minLiquidatorReward(), toSetValue);
             assertEq(origins._maxLiquidatorReward(), toSetMaxValue);
@@ -209,12 +208,13 @@ contract OriginsTest is UsdoTestHelper {
         }
     }
 
-    function test_should_not_work_when_paused() public {
+    function test_should_not_work_when_paused_origins() public {
         {
+            ICluster _cl = penrose.cluster();
+            _cl.setRoleForContract(address(this), keccak256("PAUSABLE"), true);
             origins.setMarketConfig(
                 ITapiocaOracle(address(0)),
                 "",
-                address(this), //conservator
                 0,
                 0,
                 0,

--- a/test/markets/Singularity.t.sol
+++ b/test/markets/Singularity.t.sol
@@ -280,7 +280,6 @@ contract SingularityTest is UsdoTestHelper {
                 Market.setMarketConfig.selector,
                 toSetAddress,
                 "",
-                toSetAddress,
                 toSetValue,
                 toSetValue,
                 toSetValue,
@@ -299,7 +298,6 @@ contract SingularityTest is UsdoTestHelper {
 
         {
             assertEq(address(singularity._oracle()), address(toSetAddress));
-            assertEq(singularity._conservator(), toSetAddress);
             assertEq(singularity._protocolFee(), toSetValue);
             assertEq(singularity._minLiquidatorReward(), toSetValue);
             assertEq(singularity._maxLiquidatorReward(), toSetMaxValue);
@@ -327,11 +325,12 @@ contract SingularityTest is UsdoTestHelper {
 
     function test_should_not_work_when_paused() public {
         {
+            ICluster _cl = penrose.cluster();
+            _cl.setRoleForContract(address(this), keccak256("PAUSABLE"), true);
             bytes memory payload = abi.encodeWithSelector(
                 Market.setMarketConfig.selector,
                 address(0),
                 "",
-                address(this), //conservator
                 0,
                 0,
                 0,


### PR DESCRIPTION
patch(`Pausable`): Updated pausable role [`86dtt5qep`]

Merge remote-tracking branch 'origin/GT_86dtt5qep_Add-conservator-role-to-all-pausable-contracts' into GT_backup-GT_86dtt5qep_Add-conservator-role-to-all-pausable-contracts