### PR TITLE
Min  borrow amount [`CU-86dtuhv48`]

### DIFF
--- a/contracts/markets/Market.sol
+++ b/contracts/markets/Market.sol
@@ -103,6 +103,8 @@ abstract contract Market is MarketERC20, Ownable {
     ILeverageExecutor internal leverageExecutor;
     /// @notice returns the maximum accepted slippage for liquidation
     uint256 internal maxLiquidationSlippage = 1000; //1%
+
+    uint256 internal minBorrowAmount;
     // ***************** //
     // *** CONSTANTS *** //
     // ***************** //
@@ -112,6 +114,7 @@ abstract contract Market is MarketERC20, Ownable {
 
     error ExchangeRateNotValid();
     error AllowanceNotValid();
+    error MinBorrowAmountNotMet();
 
     // ************** //
     // *** EVENTS *** //
@@ -215,7 +218,8 @@ abstract contract Market is MarketERC20, Ownable {
         uint256 _maxLiquidatorReward,
         uint256 _totalBorrowCap,
         uint256 _collateralizationRate,
-        uint256 _liquidationCollateralizationRate
+        uint256 _liquidationCollateralizationRate,
+        uint256 _minBorrowAmount
     ) external onlyOwner {
         if (address(_oracle) != address(0)) {
             oracle = _oracle;
@@ -277,6 +281,11 @@ abstract contract Market is MarketERC20, Ownable {
             require(_liquidationCollateralizationRate <= FEE_PRECISION, "Market: not valid");
             liquidationCollateralizationRate = _liquidationCollateralizationRate;
             emit ValueUpdated(8, _liquidationCollateralizationRate);
+        }
+
+        if (_minBorrowAmount > 0) {
+            minBorrowAmount = _minBorrowAmount;
+            emit ValueUpdated(9, _minBorrowAmount);
         }
     }
 

--- a/contracts/markets/MarketStateView.sol
+++ b/contracts/markets/MarketStateView.sol
@@ -130,4 +130,8 @@ abstract contract MarketStateView is Market {
     function _exchangeRatePrecision() external view returns (uint256) {
         return EXCHANGE_RATE_PRECISION;
     }
+
+    function _minBorrowAmount() external view returns (uint256) {
+        return minBorrowAmount;
+    }
 }

--- a/contracts/markets/bigBang/BBBorrow.sol
+++ b/contracts/markets/bigBang/BBBorrow.sol
@@ -41,8 +41,7 @@ contract BBBorrow is BBLendingCommon {
         solvent(from)
         returns (uint256 part, uint256 share)
     {
-        if (amount == 0) return (0, 0);
-        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
+        if (amount <= minBorrowAmount) revert MinBorrowAmountNotMet();
 
         penrose.reAccrueBigBangMarkets();
 

--- a/contracts/markets/bigBang/BBBorrow.sol
+++ b/contracts/markets/bigBang/BBBorrow.sol
@@ -42,6 +42,8 @@ contract BBBorrow is BBLendingCommon {
         returns (uint256 part, uint256 share)
     {
         if (amount == 0) return (0, 0);
+        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
+
         penrose.reAccrueBigBangMarkets();
 
         uint256 feeAmount = _computeVariableOpeningFee(amount);

--- a/contracts/markets/bigBang/BigBang.sol
+++ b/contracts/markets/bigBang/BigBang.sol
@@ -190,6 +190,7 @@ contract BigBang is MarketStateView, BBCommon {
         minMintFeeStart = 1000000000000000000; // 1*1e18
 
         leverageExecutor = _leverageExecutor;
+        minBorrowAmount = 1e15;
 
         _transferOwnership(address(penrose));
     }

--- a/contracts/markets/origins/Origins.sol
+++ b/contracts/markets/origins/Origins.sol
@@ -192,8 +192,7 @@ contract Origins is Ownable, Market, MarketStateView, ReentrancyGuard {
     {
         if (!allowedParticipants[msg.sender]) revert NotAuthorized();
 
-        if (amount == 0) return (0, 0);
-        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
+        if (amount <= minBorrowAmount) revert MinBorrowAmountNotMet();
 
         (part, share) = _borrow(msg.sender, msg.sender, amount);
     }

--- a/contracts/markets/origins/Origins.sol
+++ b/contracts/markets/origins/Origins.sol
@@ -99,6 +99,7 @@ contract Origins is Ownable, Market, MarketStateView, ReentrancyGuard {
         liquidationCollateralizationRate = 1e5;
 
         rateValidDuration = 24 hours;
+        minBorrowAmount = 1e15;
 
         _transferOwnership(_owner);
     }
@@ -192,6 +193,8 @@ contract Origins is Ownable, Market, MarketStateView, ReentrancyGuard {
         if (!allowedParticipants[msg.sender]) revert NotAuthorized();
 
         if (amount == 0) return (0, 0);
+        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
+
         (part, share) = _borrow(msg.sender, msg.sender, amount);
     }
 

--- a/contracts/markets/singularity/SGLBorrow.sol
+++ b/contracts/markets/singularity/SGLBorrow.sol
@@ -33,8 +33,7 @@ contract SGLBorrow is SGLLendingCommon {
         notSelf(to)
         returns (uint256 part, uint256 share)
     {
-        if (amount == 0) return (0, 0);
-        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
+        if (amount <= minBorrowAmount) revert MinBorrowAmountNotMet();
 
         uint256 feeAmount = (amount * borrowOpeningFee) / FEE_PRECISION;
         uint256 allowanceShare =

--- a/contracts/markets/singularity/SGLBorrow.sol
+++ b/contracts/markets/singularity/SGLBorrow.sol
@@ -34,6 +34,7 @@ contract SGLBorrow is SGLLendingCommon {
         returns (uint256 part, uint256 share)
     {
         if (amount == 0) return (0, 0);
+        if (amount < minBorrowAmount) revert MinBorrowAmountNotMet();
 
         uint256 feeAmount = (amount * borrowOpeningFee) / FEE_PRECISION;
         uint256 allowanceShare =

--- a/contracts/markets/singularity/Singularity.sol
+++ b/contracts/markets/singularity/Singularity.sol
@@ -171,6 +171,7 @@ contract Singularity is MarketStateView, SGLCommon {
         uint256 _liquidationCollateralizationRate,
         uint256 _exchangeRatePrecision
     ) private {
+        minBorrowAmount = 1e15;
         collateralizationRate = _collateralizationRate > 0 ? _collateralizationRate : 75000;
         liquidationCollateralizationRate =
             _liquidationCollateralizationRate > 0 ? _liquidationCollateralizationRate : 80000;

--- a/test/markets/BigBang.t.sol
+++ b/test/markets/BigBang.t.sol
@@ -454,7 +454,8 @@ contract BigBangTest is UsdoTestHelper {
                 toSetMaxValue,
                 toSetValue,
                 toSetValue,
-                toSetMaxValue
+                toSetMaxValue,
+                toSetValue
             );
             address[] memory mc = new address[](1);
             mc[0] = address(bigBang);
@@ -472,6 +473,7 @@ contract BigBangTest is UsdoTestHelper {
             assertEq(bigBang._totalBorrowCap(), toSetValue);
             assertEq(bigBang._collateralizationRate(), toSetValue);
             assertEq(bigBang._liquidationCollateralizationRate(), toSetMaxValue);
+            assertEq(bigBang._minBorrowAmount(), toSetValue);
         }
     }
 
@@ -489,6 +491,7 @@ contract BigBangTest is UsdoTestHelper {
                 Market.setMarketConfig.selector,
                 address(0),
                 "",
+                0,
                 0,
                 0,
                 0,

--- a/test/markets/Origins.t.sol
+++ b/test/markets/Origins.t.sol
@@ -193,7 +193,8 @@ contract OriginsTest is UsdoTestHelper {
                 toSetMaxValue,
                 toSetValue,
                 toSetValue,
-                toSetMaxValue
+                toSetMaxValue,
+                toSetValue
             );
         }
 
@@ -205,6 +206,7 @@ contract OriginsTest is UsdoTestHelper {
             assertEq(origins._totalBorrowCap(), toSetValue);
             assertEq(origins._collateralizationRate(), toSetValue);
             assertEq(origins._liquidationCollateralizationRate(), toSetMaxValue);
+            assertEq(origins._minBorrowAmount(), toSetValue);
         }
     }
 
@@ -215,6 +217,7 @@ contract OriginsTest is UsdoTestHelper {
             origins.setMarketConfig(
                 ITapiocaOracle(address(0)),
                 "",
+                0,
                 0,
                 0,
                 0,

--- a/test/markets/Singularity.t.sol
+++ b/test/markets/Singularity.t.sol
@@ -286,7 +286,8 @@ contract SingularityTest is UsdoTestHelper {
                 toSetMaxValue,
                 toSetValue,
                 toSetValue,
-                toSetMaxValue
+                toSetMaxValue,
+                toSetValue
             );
             address[] memory mc = new address[](1);
             mc[0] = address(singularity);
@@ -304,6 +305,7 @@ contract SingularityTest is UsdoTestHelper {
             assertEq(singularity._totalBorrowCap(), toSetValue);
             assertEq(singularity._collateralizationRate(), toSetValue);
             assertEq(singularity._liquidationCollateralizationRate(), toSetMaxValue);
+            assertEq(singularity._minBorrowAmount(), toSetValue);
         }
     }
 
@@ -331,6 +333,7 @@ contract SingularityTest is UsdoTestHelper {
                 Market.setMarketConfig.selector,
                 address(0),
                 "",
+                0,
                 0,
                 0,
                 0,


### PR DESCRIPTION
patch('min borrow amount'): added `minBorrowAmount` check for markets [`86dtuhv48`]

chore: minor optimization for minBorrowAmount

Merge remote-tracking branch 'origin/GT_86dtuhv48_Min--borrow-amount' into GT_backup-GT_86dtuhv48_Min--borrow-amount